### PR TITLE
Refactor npm scripts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,7 +38,9 @@ module.exports = function (eleventyConfig) {
   // Passthrough
   eleventyConfig.addPassthroughCopy('./app/documents');
   eleventyConfig.addPassthroughCopy('./app/images');
-  eleventyConfig.addPassthroughCopy('node_modules/nunjucks/browser/nunjucks-slim.js');
+  eleventyConfig.addPassthroughCopy({
+    'node_modules/govuk-frontend/govuk/assets': 'assets'
+  });
 
   // Enable data deep merge
   eleventyConfig.setDataDeepMerge(true);

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: http-server public/ -p $PORT

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Design history for GOV.UK services
 
-An example design history from the Becoming a teacher team:
-https://bat-design-history.netlify.com
+A place for you to document your GOV.UK service designs.
 
 ## Purpose of this project
 
@@ -15,27 +14,24 @@ This repository makes it easy to:
 
 ## Installation
 
-- Clone this repository to a folder on your computer
-- Open Terminal
-- In Terminal, change the path to the repository
-- Type `npm install` to install the dependencies
+* Clone this repository to a folder on your computer
+* Open Terminal
+* In Terminal, change the path to the repository
+* Type `npm install` to install the dependencies
 
 ## Working locally
 
 Most of the time you'll be adding new posts. If you're just doing this then:
 
-- Open Terminal
-- Type `npm start`
+* Open Terminal
+* Type `npm run watch`
 
-This will automatically restart the application with your changes to markdown and images applied.
+This will automatically restart the application with any changes to Markdown, images, CSS, JavaScript applied.
 
-If you're making changes to the CSS or JavaScript then:
+## Example design histories
 
-- Open Terminal
-- Type `npm run watch`
-
-This will automatically restart the application with changes to the CSS, JavaScript and markdown applied.
+* [Becoming a teacher design history](https://bat-design-history.netlify.app)
 
 ## Technical notes
 
-The design history uses the [GOV.UK Design System](https://design-system.service.gov.uk) and the [Eleventy](https://www.11ty.io) static site generator.
+The design history uses the [GOV.UK Design System](https://design-system.service.gov.uk) and the [Eleventy](https://www.11ty.dev) static site generator.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This repository makes it easy to:
 * In Terminal, change the path to the repository
 * Type `npm install` to install the dependencies
 
+### Deploying to Netlify
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/fofr/govuk-design-history)
+
+### Deploying to Heroku
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Working locally
 
 Most of the time you'll be adding new posts. If you're just doing this then:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "Design history for GOV.UK services",
+  "description": "A place for you to document your GOV.UK service designs",
+  "repository": "https://github.com/fofr/govuk-design-history",
+  "success_url": "/set-up-your-design-history"
+}

--- a/etc/rollup.config.js
+++ b/etc/rollup.config.js
@@ -11,4 +11,10 @@ module.exports = [{
     resolve(),
     commonjs()
   ]
+}, {
+  input: 'node_modules/govuk-frontend/govuk/all.js',
+  output: {
+    file: 'public/javascripts/govuk-frontend.js'
+  },
+  context: 'window'
 }]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "public"

--- a/package.json
+++ b/package.json
@@ -17,22 +17,17 @@
   "repository": "github:fofr/govuk-design-history",
   "bugs": "https://github.com/fofr/govuk-design-history/issues",
   "scripts": {
-    "prebuild": "rm -rf public/assets && mkdir -p public && mkdir -p public/javascripts && mkdir -p public/admin",
-    "build:govuk-assets": "cp -R node_modules/govuk-frontend/govuk/assets public/assets",
-    "build:govuk-scripts": "cp node_modules/govuk-frontend/govuk/all.js public/javascripts/govuk-frontend.js",
-    "build:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --include-path app",
+    "prebuild": "rm -rf public",
+    "build:files": "eleventy",
     "build:javascripts": "rollup --config etc/rollup.config.js",
-    "build:pages": "npx eleventy",
+    "build:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --include-path app",
     "build": "npm-run-all --serial build:*",
     "prewatch": "npm run build",
-    "watch:files": "eleventy --serve",
+    "watch:files": "eleventy --serve --quiet",
     "watch:javascripts": "rollup --config etc/rollup.config.js --watch",
     "watch:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --watch",
     "watch": "npm-run-all --parallel watch:*",
-    "lint": "standard",
-    "prestart": "npm run build",
-    "start": "npx eleventy --serve",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "standard"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.11.0",
@@ -42,7 +37,8 @@
     "@rollup/plugin-node-resolve": "^7.1.3",
     "accessible-autocomplete": "^2.0.1",
     "dotenv": "^8.2.0",
-    "govuk-frontend": "^3.5.0",
+    "govuk-frontend": "^3.7.0",
+    "http-server": "^0.12.3",
     "lodash": "^4.17.15",
     "luxon": "^1.21.3",
     "markdown-it-abbr": "^1.0.4",
@@ -57,11 +53,11 @@
     "node-sass": "^4.13.1",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.16.1",
-    "sharp": "^0.25.4",
-    "webshot-node": "^0.18.2"
+    "sharp": "^0.25.4"
   },
   "devDependencies": {
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "webshot-node": "^0.18.2"
   },
   "nodemonConfig": {
     "ext": "css, scss, js, json, md, njk"


### PR DESCRIPTION
## Refactor npm scripts

* Copy `govuk-frontend`’s assets to destination folder using 11ty’s `addPassthroughCopy` function (removing need for `build:govuk-assets` script)
* Copy `govuk-frontend`’s JavaScript’s to destination folder in Rollup config (removing need for `build:govuk-scripts` script)
* The above changes mean we no longer ned to make any directories prior to rebuilding site (`prebuild` now just deletes the destination folder)
* Remove `prestart` and `start` commands
* Move `standard` from `lint` to `test`

Essentially, this simplifies things by having only three task groupings:
* **Watch**: start a sever, watch for changes, and refresh the browser when they occur. `npm run watch` calls `npm run build` when it is first executed.
* **Build**: generate all files and assets
* **Test**: Used for JavaScript linting, for now.

## Deploying to Heroku

When deploying a node app, Heroku performs the following:
* Installs dependancies (`npm install`)
* Runs any `build` scripts
* Starts the server (either `npm start` or whatever command is declared in a `Procfile`. 

Given the above changes, we only need add a `Procfile`, which starts a server once the site has been built.

## Deploying to Netlify

Netlify doesn’t need a server, it just needs to build the files before deploying them to its CDN. Adding a `netlify.toml` file tells Netlify which command to run, in this case `npm run build`.

## Other fixes

* Update README.md to reflect above changes, consistent bullet syntax, and move BAT history to list of example histories.
* Watch files using 11ty’s `--quite` mode
* Remove unnecessary passthrough file copy (holdover from previous Netlify CMS implementation)
* Use correct version number for `govuk-frontend`
