### PR TITLE
Add dev and start commands to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ This repository makes it easy to:
 Most of the time you'll be adding new posts. If you're just doing this then:
 
 * Open Terminal
-* Type `npm run watch`
+* Type `npm start`
 
-This will automatically restart the application with any changes to Markdown, images, CSS, JavaScript applied.
+This will automatically restart the application with any changes to your posts an any images applied.
+
+If you want to make changes to CSS and JavaScript, and watch for those changes, run `npm run dev`.
 
 ## Example design histories
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "watch:javascripts": "rollup --config etc/rollup.config.js --watch",
     "watch:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --watch",
     "watch": "npm-run-all --parallel watch:*",
+    "dev": "npm run watch",
+    "start": "npm run watch:files",
     "test": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
Aliases `npm start` to `npm run watch:files`, and aliases `npm run dev` to `npm run watch`. Updates README with these two user-facing commands.