### PR TITLE
Build all files before starting server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "watch:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --watch",
     "watch": "npm-run-all --parallel watch:*",
     "dev": "npm run watch",
+    "prestart": "npm run build",
     "start": "npm run watch:files",
     "test": "standard"
   },


### PR DESCRIPTION
`npm start` builds pages, but doesn’t build assets. This should fix that.