### PR TITLE
Update docs on how to split history into different sections

### DIFF
--- a/app/posts/2019-12-31-example-post.md
+++ b/app/posts/2019-12-31-example-post.md
@@ -16,7 +16,7 @@ Some real examples are:
 
 After screenshots were saved to the `app/images/example-post` directory, [this page was generated](https://github.com/DFE-Digital/govuk-design-history/pull/11/commits/473f5aca5d978a3d18ac188b98c6c8ef6c000713) using the following command:
 
-```
+```bash
 node scripts/generate.js example-post
 ```
 

--- a/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
+++ b/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
@@ -36,6 +36,7 @@ Next, create a page that lists these related posts. You can do that by creating 
 2. Add these values to the frontmatter:
 
     ``` yaml
+    {% raw %}
     ---
     tags: false
     layout: collection
@@ -52,6 +53,7 @@ Next, create a page that lists these related posts. You can do that by creating 
         excerpt: "{{ description }}"
         parent: home
     ---
+    {% endraw %}
     ```
 
     You do not need to add any body content, but if you do, this will appear above the list of posts in this section.

--- a/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
+++ b/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
@@ -56,6 +56,9 @@ Next, create a page that lists these related posts. You can do that by creating 
 
     You do not need to add any body content, but if you do, this will appear above the list of posts in this section.
 
-### Update the home page to link to each section
+## Update the home page to link to each section
 
-Currently the homepage lists all posts in the site. You can change this to link to the different section indexes instead by removing the pagination value from the frontmatter in `app/index.md`.
+Currently the homepage lists all posts on the site. To change it so that only sections are linked to instead:
+
+1. Remove `pagination` from the frontmatter in `app/index.md`.
+2. Remove `eleventyComputed.eleventyNavigation.parent` from `app/posts/posts.json`

--- a/app/posts/2020-01-03-set-up-a-design-history.md
+++ b/app/posts/2020-01-03-set-up-a-design-history.md
@@ -116,7 +116,7 @@ We’ve found it’s better to keep a design history public. But if you need to 
 * set a `USERNAME` and `PASSWORD` environment variable on your Heroku app ([a guide on how to do this](https://devcenter.heroku.com/articles/config-vars#managing-config-vars))
 * update the [`Procfile`](https://github.com/DFE-Digital/govuk-design-history/blob/main/Procfile) with:
 
-```
+```text
 web: http-server --username $USERNAME --password $PASSWORD -p $PORT
 ```
 

--- a/app/posts/2020-01-05-what-is-a-design-history.md
+++ b/app/posts/2020-01-05-what-is-a-design-history.md
@@ -19,4 +19,4 @@ This project was developed by the Becoming a teacher team at the Department for 
 * share design decisions across government
 * share everything with service assessors
 
-As of February 2020, the [Becoming a teacher design history](https://bat-design-history.netlify.app) includes more than 200 posts documenting 5 different services.<!-- You can learn more about how and why the team created their design history on the [DfE Digital blog](#tbd).-->
+As of February 2020, the [Becoming a teacher design history](https://bat-design-history.netlify.app) includes more than 200 posts documenting 5 different services. You can learn more about how and why the team created their design history on the [DfE Digital blog](https://dfedigital.blog.gov.uk/2020/09/01/design-history/).


### PR DESCRIPTION
Update the docs to add an additional change needed to ensure that a homepage lists only sections and not posts.

Based on the experience the EYFS team had making this work. See https://github.com/rinto-c/eyfs-design-history/pull/1

In addition:

* Adds link to DfE Digital blog post
* Fixes not showing raw Nunjucks templates in example code block
* Adds missing syntax type to 2 code blocks