### PR TITLE
Add grid markup to stop the post heading from getting too long

### DIFF
--- a/app/_components/article/template.njk
+++ b/app/_components/article/template.njk
@@ -1,7 +1,11 @@
 <article class="app-article">
   {% if params.header %}
   <header class="app-article__header">
-    <h1 class="app-article__title govuk-heading-xl">{{ params.header.title }}</h1>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="app-article__title govuk-heading-xl">{{ params.header.title }}</h1>
+      </div>
+    </div>
   </header>
   {% endif %}
 


### PR DESCRIPTION
I spotted a design history in the wild with a long post heading. I think it looks a bit broken when the heading can span the entire width of the container. 

Please Design History gods, consider this request for an update and I offer you this screenshot as a proof of my unwavering devotion to you. 

![Screenshot 2021-02-22 at 12 50 22](https://user-images.githubusercontent.com/1108991/108711038-b31cd280-750c-11eb-9c49-d3f2ac40253f.png)


