### PR TITLE
Add plugin to support markdown figure syntax. Fixes #64

### DIFF
--- a/lib/libraries/markdown.js
+++ b/lib/libraries/markdown.js
@@ -19,6 +19,9 @@ module.exports = (() => {
     .use(require('markdown-it-deflist'))
     .use(require('markdown-it-footnote'))
     .use(require('markdown-it-ins'))
+    .use(require('markdown-it-image-figures'), {
+      figcaption: true
+    })
     .use(require('markdown-it-mark'))
     .use(require('markdown-it-sub'))
     .use(require('markdown-it-sup'))

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "markdown-it-anchor": "^8.1.2",
     "markdown-it-deflist": "^2.1.0",
     "markdown-it-footnote": "^3.0.2",
+    "markdown-it-image-figures": "^2.0.0",
     "markdown-it-ins": "^3.0.1",
     "markdown-it-mark": "^3.0.1",
     "markdown-it-sub": "^1.0.0",


### PR DESCRIPTION
Adds missing plugin that enables posts to use Markdown’s image syntax (with a title) to generate figures with captions.