### PR TITLE
Only show related items if any are present

### DIFF
--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -57,7 +57,7 @@
               items: pagination.hrefs
             }) }}
           </section>
-          {% if related %}
+          {% if related.items | length > 0 %}
             <div class="govuk-grid-column-one-third">
               {{ appRelated({
                 title: related.title or "Related links",

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -28,7 +28,7 @@
       {% endfor %}
     </div>
 
-    {% if related %}
+    {% if related.items | length > 0 %}
     <div class="govuk-grid-column-one-third">
       {{ appRelated({
         title: related.title or "Related links",


### PR DESCRIPTION
The headless CMS Forestry tends to save an empty array `[]` for related items. Unless we test for the size, an empty array will show ‘Related links’ in the sidebar, but without actually having any links to show.