### PR TITLE
Simplify npm scripts

### DIFF
--- a/app/posts/2020-01-03-set-up-a-design-history.md
+++ b/app/posts/2020-01-03-set-up-a-design-history.md
@@ -111,10 +111,10 @@ The process is very similar to [setting up a prototype on Heroku](https://govuk-
 
 #### Password protect your design history
 
-We’ve found it’s better to keep a design history public. But if you need to password protect yours you can add a username and password using environment variables (Heroku calls these “config vars”):
+We’ve found it’s better to keep a design history public. But if you need to password protect yours, you can add a username and password using environment variables (Heroku calls these “config vars”):
 
-* set a `USERNAME` and `PASSWORD` environment variable on your Heroku app ([a guide on how to do this](https://devcenter.heroku.com/articles/config-vars#managing-config-vars))
-* update the [`Procfile`](https://github.com/DFE-Digital/govuk-design-history/blob/main/Procfile) with:
+* set `USERNAME` and `PASSWORD` environment [variables on your Heroku app](https://devcenter.heroku.com/articles/config-vars#managing-config-vars)
+* update the [`Procfile`](https://devcenter.heroku.com/articles/procfile) in the root folder with the following content:
 
 ```text
 web: http-server --username $USERNAME --password $PASSWORD -p $PORT

--- a/package.json
+++ b/package.json
@@ -19,11 +19,8 @@
   "scripts": {
     "prebuild": "rimraf public",
     "build": "eleventy",
-    "prewatch": "npm run build",
-    "watch": "eleventy --serve --quiet",
-    "dev": "npm run watch",
     "prestart": "npm run build",
-    "start": "npm run watch",
+    "start": "eleventy --serve --quiet",
     "test": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
This PR simplifies the npm scripts:
  * `npm run dev`: Build the site and serve it using 11ty (aka Browser Sync) and watch for any changes
  * `npm run build`: Builds the site. Suitable for static hosts like Netlify
  * `npm start`: Builds the site and serves it on `process.env.PORT`. Suitable for application servers like Heroku

Documentation has been updated to reflect this change.

We no longer need a `Procfile` because:

* The default process is `web`
* The default command to for starting Node.js apps on Heroku is `npm start` 
* `npm start` runs `http-server`
* `http-server` doesn’t need a `$PORT` variable declared as it uses this by default if no port value is declared 

**UPDATE:** Simplified scripts by removing `npm run dev` and `npm run watch` tasks only.