### PR TITLE
Allow screenshots macro to be backwards compatible

### DIFF
--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -17,7 +17,7 @@
 {% for item in params.items -%}
   {%- set itemTitle = item.text or item -%}
   {%- set itemId = item.id or (itemTitle | slugify) -%}
-  {%- set file = item.src or (itemId + ".png") -%}
+  {%- set file = item.src or (item.img and item.img.src) or (itemId + ".png") -%}
   {%- set alt = item.alt or ("Screenshot of " + itemTitle) -%}
   <figure class="app-screenshots__screenshot" id="{{ itemId }}">
     <h{{ headingLevel + 1 }} tabindex="-1">


### PR DESCRIPTION
The old syntax generated was:

```
{
  text: "You are now signed in",
  img: { src: "07-a-you-are-now-signed-in.png" }
}
```

This allows design histories to be updated to the new screenshots frontmatter and relative images without needing to update any of the old macros.