### PR TITLE
Update frontmatter in docs. Fixes #86

### DIFF
--- a/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
+++ b/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
@@ -38,7 +38,7 @@ Next, create a page that lists these related posts. You can do that by creating 
     ``` yaml
     {% raw %}
     ---
-    tags: false
+    override:tags: []
     layout: collection
     title: Service support interface
     description: A tool for support agents to manage the service


### PR DESCRIPTION
`tags:false` was how you would override tags prior to Eleventy 1.0.0. Now that this project is using `v1.0.0`, the examples needs to be updated to use the revised syntax: `override:tags: []`.