### PR TITLE
 Lint and fix markdown

### DIFF
--- a/app/posts/2019-12-31-example-post.md
+++ b/app/posts/2019-12-31-example-post.md
@@ -18,9 +18,9 @@ This is an example of a standard design history post – it begins with a preamb
 
 Some real examples are:
 
-* [Apply for teacher training: Reasons for withdrawing an application](https://bat-design-history.netlify.app/apply-for-teacher-training/reason-for-withdraw/)
-* [Manage teacher applications: Deferring an application](https://bat-design-history.netlify.app/manage-teacher-training-applications/deferring-applications-to-the-next-cycle/)
-* [Find postgraduate teacher training: A snapshot of the service](https://bat-design-history.netlify.app/find-teacher-training/find-december-2019/)
+- [Apply for teacher training: Reasons for withdrawing an application](https://bat-design-history.netlify.app/apply-for-teacher-training/reason-for-withdraw/)
+- [Manage teacher applications: Deferring an application](https://bat-design-history.netlify.app/manage-teacher-training-applications/deferring-applications-to-the-next-cycle/)
+- [Find postgraduate teacher training: A snapshot of the service](https://bat-design-history.netlify.app/find-teacher-training/find-december-2019/)
 
 ## This page was generated
 

--- a/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
+++ b/app/posts/2020-01-01-divide-a-design-history-into-different-sections.md
@@ -18,14 +18,14 @@ You can create a section by grouping related posts. You can do this in 2 ways; k
 
 4. In this JSON file, declare a tag which should be used to group these related posts, and a parent name to use in the breadcrumb navigation (the parent being the name of this section). For example
 
-    ```` json
-    {
-      "tags": ["support-interface"],
-      "eleventyNavigation": {
-        "parent": "Service support interface"
-      }
-    }
-    ````
+   ```json
+   {
+     "tags": ["support-interface"],
+     "eleventyNavigation": {
+       "parent": "Service support interface"
+     }
+   }
+   ```
 
 ## Create an index page for each section
 
@@ -33,34 +33,36 @@ Next, create a page that lists these related posts. You can do that by creating 
 
 1. Within the subfolder created in the previous step, create a markdown file, with the same name as the folder. For example, for the folder app/posts/support-interface/, add the file app/posts/support-interface/support-interface.md
 
-2. Add these values to the frontmatter:
+2. Add these values to the front matter:
 
-    ``` yaml
-    {% raw %}
-    ---
-    override:tags: []
-    layout: collection
-    title: Service support interface
-    description: A tool for support agents to manage the service
-    pagination:
-      data: collections.support-interface
-      reverse: true
-      size: 50
-    permalink: "support-interface/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
-    eleventyComputed:
-      eleventyNavigation:
-        key: "{{ title }}"
-        excerpt: "{{ description }}"
-        parent: home
-    ---
-    {% endraw %}
-    ```
+   {% raw %}
 
-    You do not need to add any body content, but if you do, this will appear above the list of posts in this section.
+   ```yaml
+   ---
+   override:tags: []
+   layout: collection
+   title: Service support interface
+   description: A tool for support agents to manage the service
+   pagination:
+     data: collections.support-interface
+     reverse: true
+     size: 50
+   permalink: "support-interface/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
+   eleventyComputed:
+     eleventyNavigation:
+       key: "{{ title }}"
+       excerpt: "{{ description }}"
+       parent: home
+   ---
+   ```
+
+   {% endraw %}
+
+   You do not need to add any body content, but if you do, this will appear above the list of posts in this section.
 
 ## Update the home page to link to each section
 
 Currently the homepage lists all posts on the site. To change it so that only sections are linked to instead:
 
-1. Remove `pagination` from the frontmatter in `app/index.md`.
+1. Remove `pagination` from the front matter in `app/index.md`.
 2. Remove `eleventyComputed.eleventyNavigation.parent` from `app/posts/posts.json`

--- a/app/posts/2020-01-02-generate-a-page-of-screenshots.md
+++ b/app/posts/2020-01-02-generate-a-page-of-screenshots.md
@@ -4,8 +4,8 @@ description: Learn how to use the 2 scripts that generate posts containing a ser
 date: 2020-01-02
 related:
   items:
-  - text: An example post with screenshots
-    href: /example-post
+    - text: An example post with screenshots
+      href: /example-post
 ---
 
 The design history project provides 2 scripts to help you generate a post featuring a list of screenshots. [See an example](/example-post/).
@@ -16,29 +16,31 @@ The first allows you to capture these screenshots from a sequence of URLs, perha
 
 1. Open `scripts/screenshot.js`. In this file you will see 2 values:
 
-    * `domain`: the website you want to screenshot, eg localhost:3000
-    * `paths`: an array of named paths
+   - `domain`: the website you want to screenshot, eg localhost:3000
+   - `paths`: an array of named paths
 
-    Replace these with your desired values.
+   Replace these with your desired values.
 
 2. In the terminal, type:
 
-    `node scripts/screenshot.js [name-of-your-feature]`
+   ```shell
+   node scripts/screenshot.js [name-of-your-feature]
+   ```
 
-    This will:
+   This will:
 
-    * visit each page lists in paths and save a screenshot
-    * save those screenshots in the named directory
-    * generate an index page with screenshots listed in order
+   - visit each page lists in paths and save a screenshot
+   - save those screenshots in the named directory
+   - generate an index page with screenshots listed in order
 
 ### Example
 
 With the following values in `scripts/screenshots.js`:
 
-``` js
+```js
 const domain = 'http://localhost:3000'
 const paths = [
-  { title: 'Start page', path: '/'},
+  { title: 'Start page', path: '/' },
   { title: 'Personal details', path: '/personal-details' },
   { title: 'Check your answers', path: '/check-your-answers' },
   { title: 'Confirmation', path: '/confirmation' }
@@ -47,14 +49,14 @@ const paths = [
 
 running `node scripts/screenshot.js submit-personal-details` will generate the following images:
 
-* `app/images/submit-personal-details/start-page.png`
-* `app/images/submit-personal-details/personal-details.png`
-* `app/images/submit-personal-details/check-your-answers.png`
-* `app/images/submit-personal-details/confirmation-page.png`
+- `app/images/submit-personal-details/start-page.png`
+- `app/images/submit-personal-details/personal-details.png`
+- `app/images/submit-personal-details/check-your-answers.png`
+- `app/images/submit-personal-details/confirmation-page.png`
 
 A post will also be created, using the name of the directory and current date, for example:
 
-* `app/posts/{{ "now" | date("y-LL-dd") }}-submit-personal-details.md`
+- `app/posts/{{ "now" | date("y-LL-dd") }}-submit-personal-details.md`
 
 ## Generate a page of screenshots from a folder of images
 
@@ -64,17 +66,17 @@ A post will also be created, using the name of the directory and current date, f
 
 3. In the terminal, type:
 
-    ``` shell
-    node scripts/generate.js [name-of-directory-holding-images]
-    ```
+   ```shell
+   node scripts/generate.js [name-of-directory-holding-images]
+   ```
 
-    This will generate an index page with screenshots listed in order, creating a post using the name of the containing folder.
+   This will generate an index page with screenshots listed in order, creating a post using the name of the containing folder.
 
 ## The generated post
 
 This file will be pre-populated with a title, date, and a list of screenshots:
 
-``` yaml
+```yaml
 ---
 title: Submit personal details
 date: {{ "now" | date("y-LL-dd") }}
@@ -89,7 +91,7 @@ screenshots:
 
 If you want to change the name of any images, you can use the `src` value to tell the screenshots component what filename to look for, for example:
 
-``` yaml
+```yaml
 title: Submit personal details
 date: {{ "now" | date("y-LL-dd") }}
 screenshots:

--- a/app/posts/2020-01-03-set-up-a-design-history.md
+++ b/app/posts/2020-01-03-set-up-a-design-history.md
@@ -25,13 +25,13 @@ Start by making a copy of this project. The easiest way to do this is on GitHub.
 
 To start making changes, you’ll need to download the repository to your own computer. Assuming your GitHub user is `my-username`, and you called your repository `my-service-design-history`, using the Terminal you would type:
 
-``` text
+```shell
 git clone git@github.com:my-username/my-service-design-history.git
 ```
 
 Next, change into the downloaded folder, and install all the dependencies needed to run the design history project. Do this by typing the following:
 
-``` text
+```shell
 cd my-service-design-history
 npm install
 ```
@@ -40,7 +40,7 @@ npm install
 
 Before uploading your design history to a public URL, it can be useful to preview it locally, on your own computer. To do this type:
 
-``` text
+```shell
 npm start
 ```
 
@@ -83,9 +83,9 @@ You’re now ready to start documenting your designs. To add a new post:
 
     For example: `2020-02-19-first-designs.md` will create a page that can be reached at `<your-design-history>/first-designs/`
 
-2. Posts are made up of 2 parts: a frontmatter and its contents.
+2. Posts are made up of 2 parts: a front matter and its contents.
 
-    A frontmatter starts and ends with `---` and is written using a key/value data format called YAML. In most cases, you will only need three bits of information: `title`, `description` and `date`. For example:
+   A front matter starts and ends with `---` and is written using a key/value data format called YAML. In most cases, you will only need three bits of information: `title`, `description` and `date`. For example:
 
     ``` yaml
     ---

--- a/app/posts/2020-01-04-keeping-a-design-history.md
+++ b/app/posts/2020-01-04-keeping-a-design-history.md
@@ -24,14 +24,14 @@ New posts show the team where the service is going. They highlight what will be 
 
 Old posts tell us how we got here. With them we can:
 
-* discover what we did and why
-* re-evaluate decisions
-* see how a feature has changed
-* see how things tested in research
-* give context to new team members
-* see what didn’t work
-* see things we tried but didn’t build
-* see how things looked at significant milestones
+- discover what we did and why
+- re-evaluate decisions
+- see how a feature has changed
+- see how things tested in research
+- give context to new team members
+- see what didn’t work
+- see things we tried but didn’t build
+- see how things looked at significant milestones
 
 By making the design history open we can share our designs and our reasoning behind them. Whether that’s with colleagues, other teams, the rest of government, or with service assessors. [Make things open, it makes things better](https://www.gov.uk/guidance/government-design-principles#make-things-open-it-makes-things-better).
 

--- a/app/posts/2020-01-05-what-is-a-design-history.md
+++ b/app/posts/2020-01-05-what-is-a-design-history.md
@@ -10,13 +10,13 @@ A design history site is like a blog, with posts describing the development of n
 
 This project was developed by the Becoming a teacher team at the Department for Education who found that by keeping a design history, they could:
 
-* re-evaluate decisions
-* see how a feature changed over time
-* see how things tested in research
-* give context to new team members
-* demonstrate reasons why certain features did not work
-* create snapshots of how things looked at significant milestones
-* share design decisions across government
-* share everything with service assessors
+- re-evaluate decisions
+- see how a feature changed over time
+- see how things tested in research
+- give context to new team members
+- demonstrate reasons why certain features did not work
+- create snapshots of how things looked at significant milestones
+- share design decisions across government
+- share everything with service assessors
 
 As of February 2020, the [Becoming a teacher design history](https://bat-design-history.netlify.app) includes more than 200 posts documenting 5 different services. You can learn more about how and why the team created their design history on the [DfE Digital blog](https://dfedigital.blog.gov.uk/2020/09/01/design-history/).


### PR DESCRIPTION
* Inform users to use `npm run dev`, as that’s the command that actually does what the description below says:
  
  > Whenever you add a new post, or edit an existing post, the browser will automatically refresh the page with any changes applied.

  (`npm start` only starts a server, it doesn’t watch for changes). Partially addresses #141.

* Clean up Markdown, ensuring terminal commands use `shell` highlighting with a black background to distinguish them from code examples.