### PR TITLE
Update eleventy plugin to 2.2.0, move related content alongside main content

### DIFF
--- a/app/_layouts/home.njk
+++ b/app/_layouts/home.njk
@@ -26,9 +26,9 @@
           items: pagination.hrefs
         }) }}
       </section>
-      {% if related.sections[0].items | length > 0 %}
+      {% if aside or related %}
         <div class="govuk-grid-column-one-third">
-          {{ xGovukRelatedNavigation(related) }}
+          {% include "layouts/shared/related.njk" %}
         </div>
       {% endif %}
     {# List sections (pages with a parent that is the homepage) if homepage has no pagination key set #}

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -3,34 +3,32 @@
 {% from "screenshots/macro.njk" import appScreenshots %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% call appArticle({
-        header: {
-          title: title
-        },
-        footer: {
-          date: date,
-          modified: modified,
-          author: author,
-          authors: authors
-        },
-        image: image
-      }) %}
+  {% call appArticle({
+    header: {
+      title: title
+    },
+    footer: {
+      date: date,
+      modified: modified,
+      author: author,
+      authors: authors
+    },
+    image: image
+  }) %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
         {{ content }}
-
         {% for collection in screenshots %}
           {{ appScreenshots(collection) }}
         {% else %}
           {{ appScreenshots(screenshots) if screenshots }}
         {% endfor %}
-      {% endcall %}
+      </div>
+      {% if aside or related %}
+      <div class="govuk-grid-column-one-third">
+        {% include "layouts/shared/related.njk" %}
+      </div>
+      {% endif %}
     </div>
-
-    {% if related.sections[0].items | length > 0 %}
-    <div class="govuk-grid-column-one-third">
-      {{ xGovukRelatedNavigation(related) }}
-    </div>
-    {% endif %}
-  </div>
+  {% endcall %}
 {% endblock %}

--- a/app/posts/2020-01-04-keeping-a-design-history.md
+++ b/app/posts/2020-01-04-keeping-a-design-history.md
@@ -2,6 +2,12 @@
 title: How a design history has helped
 description: A case study on the Becoming a Teacher team’s design history – how it’s been used and the story behind it.
 date: 2020-01-04
+related:
+  sections:
+    - title: Related content
+      items:
+        - text: Becoming a teacher design history
+          href: https://bat-design-history.netlify.app/
 ---
 
 On the Becoming a teacher team, we've been using a design history to document the evolution of the Find postgraduate teacher training and Apply for teacher training services since they began in May 2018.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^1.0.1",
-        "govuk-eleventy-plugin": "^2.0.0",
+        "govuk-eleventy-plugin": "^2.2.0",
         "http-server": "^14.0.0",
         "rimraf": "^3.0.2",
         "sass": "^1.52.1"
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.2.tgz",
+      "integrity": "sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/govuk-eleventy-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-2.0.1.tgz",
-      "integrity": "sha512-OJqQn5Kzd3IoianFxg5L8z/IYnUTc3tGB3CmKojLlpP017Fj+egoTPzchkwDxTanVjI3Fx19GsszVkCMbn860Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-2.2.0.tgz",
+      "integrity": "sha512-Znus6m+EYjPAsE4gsLy3HKlE6m5tX0GDjx28JDL0/lcxZYcjS6zoY7DlpChMHj4U7yk8hqSyxaDkh+UC13YJqw==",
       "dependencies": {
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
@@ -2588,8 +2588,8 @@
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.1.1",
         "deepmerge": "^4.2.2",
-        "govuk-frontend": "4.0.1",
-        "govuk-prototype-components": "^0.1.5",
+        "govuk-frontend": "^4.1.0",
+        "govuk-prototype-components": "^0.2.0",
         "luxon": "^2.1.1",
         "markdown-it-abbr": "^1.0.4",
         "markdown-it-anchor": "^8.4.1",
@@ -2611,20 +2611,22 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
     },
     "node_modules/govuk-prototype-components": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/govuk-prototype-components/-/govuk-prototype-components-0.1.5.tgz",
-      "integrity": "sha512-ssUW5qcxnyJ9B+TRafRjLdeMmAK67cC5TE5TzkVhoMDzdYTQWzfp+FtFg2SFM0dO9pAc1npMVxZ8rUxEA174IQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-components/-/govuk-prototype-components-0.2.0.tgz",
+      "integrity": "sha512-v6KzvdXlT6TOi5uIS/hG80IK2yaJoOOg7wFKMEc9PDC8rhqhBd5/x03QxZs0XBcB8kizY6hM3dKw3U7BgTBD2g==",
       "dependencies": {
+        "@11ty/eleventy": "^1.0.0",
         "accessible-autocomplete": "^2.0.4",
         "eventslibjs": "^1.2.0",
+        "govuk-eleventy-plugin": "^2.0.0-beta",
         "govuk-frontend": "^4.0.1",
         "lodash": "^4.17.21"
       },
@@ -5222,9 +5224,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -6056,9 +6058,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6549,9 +6551,9 @@
       "integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg=="
     },
     "@babel/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.2.tgz",
+      "integrity": "sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -8434,9 +8436,9 @@
       }
     },
     "govuk-eleventy-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-2.0.1.tgz",
-      "integrity": "sha512-OJqQn5Kzd3IoianFxg5L8z/IYnUTc3tGB3CmKojLlpP017Fj+egoTPzchkwDxTanVjI3Fx19GsszVkCMbn860Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-2.2.0.tgz",
+      "integrity": "sha512-Znus6m+EYjPAsE4gsLy3HKlE6m5tX0GDjx28JDL0/lcxZYcjS6zoY7DlpChMHj4U7yk8hqSyxaDkh+UC13YJqw==",
       "requires": {
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
@@ -8444,8 +8446,8 @@
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.1.1",
         "deepmerge": "^4.2.2",
-        "govuk-frontend": "4.0.1",
-        "govuk-prototype-components": "^0.1.5",
+        "govuk-frontend": "^4.1.0",
+        "govuk-prototype-components": "^0.2.0",
         "luxon": "^2.1.1",
         "markdown-it-abbr": "^1.0.4",
         "markdown-it-anchor": "^8.4.1",
@@ -8464,17 +8466,19 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
     },
     "govuk-prototype-components": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/govuk-prototype-components/-/govuk-prototype-components-0.1.5.tgz",
-      "integrity": "sha512-ssUW5qcxnyJ9B+TRafRjLdeMmAK67cC5TE5TzkVhoMDzdYTQWzfp+FtFg2SFM0dO9pAc1npMVxZ8rUxEA174IQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-components/-/govuk-prototype-components-0.2.0.tgz",
+      "integrity": "sha512-v6KzvdXlT6TOi5uIS/hG80IK2yaJoOOg7wFKMEc9PDC8rhqhBd5/x03QxZs0XBcB8kizY6hM3dKw3U7BgTBD2g==",
       "requires": {
+        "@11ty/eleventy": "^1.0.0",
         "accessible-autocomplete": "^2.0.4",
         "eventslibjs": "^1.2.0",
+        "govuk-eleventy-plugin": "^2.0.0-beta",
         "govuk-frontend": "^4.0.1",
         "lodash": "^4.17.21"
       }
@@ -10464,9 +10468,9 @@
       },
       "dependencies": {
         "immutable": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-          "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
         }
       }
     },
@@ -11099,9 +11103,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
     },
     "ua-parser-js": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^1.0.1",
-    "govuk-eleventy-plugin": "^2.0.0",
+    "govuk-eleventy-plugin": "^2.2.0",
     "http-server": "^14.0.0",
     "rimraf": "^3.0.2",
     "sass": "^1.52.1"


### PR DESCRIPTION
- [Update eleventy plugin and dependencies](https://github.com/x-govuk/govuk-design-history/commit/6f97d83c5276246c26c6cac383ec32c5cd6a5d66)
- [Show related links inline with content](https://github.com/x-govuk/govuk-design-history/commit/578015cbbb204f8afbcd44cef4328c8cd70d1230) – see https://github.com/x-govuk/govuk-eleventy-plugin/issues/49
- Use the partial that the new eleventy plugin shares to render related content and aside content on posts and index pages

![localhost_8080_keeping-a-design-history_](https://user-images.githubusercontent.com/319055/170249841-bf8f761f-1871-4ba3-9aac-96673ebdb253.png)

