### PR TITLE
Add post collection and only show posts on homepage

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -4,7 +4,7 @@ layout: home
 title: "A design history for your GOV.UK service"
 description: "Document and share design decisions. Create a permanent record of how your service has developed over time."
 pagination:
-  data: collections.all
+  data: collections.post
   reverse: true
   size: 50
 posts:

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,5 +1,6 @@
 {
   "layout": "post",
   "includeInBreadcrumbs": true,
-  "permalink": "{{ page.filePathStem | replace('posts/', '') }}/"
+  "permalink": "{{ page.filePathStem | replace('posts/', '') }}/",
+  "tags": ["post"]
 }


### PR DESCRIPTION
You can’t quite see it, but given the homepage currently lists `collection.all`, the first item is for `/styles/application.css`, but because it doesn’t have a title or other meta data, only adds an empty list item with an empty link.

We should explicitly create a `post` collection, and only list posts on the home page.

| Before | After |
| - | - |
| <img width="640" alt="Screenshot 2022-06-04 at 23 45 26" src="https://user-images.githubusercontent.com/813383/172027699-e29c5f73-f692-452f-afbc-d08a68dba149.png"> | <img width="640" alt="Screenshot 2022-06-04 at 23 45 14" src="https://user-images.githubusercontent.com/813383/172027696-18fac0fe-d04b-406c-95cf-a83aec4a8ea9.png"> |