### PR TITLE
Explicit npm scripts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: http-server -p $PORT
+web: npm run serve

--- a/package.json
+++ b/package.json
@@ -11,10 +11,9 @@
   "scripts": {
     "prebuild": "rimraf public",
     "build": "eleventy",
-    "predev": "npm run build",
-    "dev": "eleventy --serve --quiet",
-    "prestart": "npm run build",
-    "start": "http-server",
+    "start": "eleventy --serve --quiet",
+    "preserve": "npm run build",
+    "serve": "http-server",
     "test": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
Each script now does what it says on the tin:

* `npm start` - starts Eleventy using its BrowserSync server (useful for development, refreshes browser as files are changed)
* `npm run build` - generates site files only
* `npm run serve` - starts `http-server`. As this depends on there being a `public` folder, a `preserve` tasks runs beforehand.

The `Procfile` is configured to launch `npm run serve`.

This PR also means the documentation now matches the configured tasks.

Context: #141 and #146