### PR TITLE
Fix styling of screenshot heading links

### DIFF
--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -4,7 +4,7 @@
 <section class="app-screenshots app-prose govuk-!-margin-top-9" id="{{ id }}">
   <div class="govuk-!-display-none-print">
     <h{{ headingLevel }} class="govuk-heading-l" tabindex="-1">
-      <a class="app-heading-anchor" href="#{{ id }}">{{ title }}</a>
+      <a class="app-link--heading govuk-link" href="#{{ id }}">{{ title }}</a>
     </h{{ headingLevel }}>
     <ul class="govuk-list app-screenshots__contents">
       {%- for item in params.items %}
@@ -21,7 +21,7 @@
   {%- set alt = item.alt or ("Screenshot of " + itemTitle) -%}
   <figure class="app-screenshots__screenshot" id="{{ itemId }}">
     <h{{ headingLevel + 1 }} class="govuk-heading-m" tabindex="-1">
-      <a class="app-heading-anchor" href="#{{ itemId }}">{{ itemTitle }}</a>
+      <a class="app-link--heading govuk-link" href="#{{ itemId }}">{{ itemTitle }}</a>
     </h{{ headingLevel + 1 }}>
     <a class="govuk-link" href="{{ file }}"><img src="{{ file }}" alt="{{ alt }}"></a>
     {%- if item.caption %}<figcaption>{{ item.caption | markdown | safe }}</figcaption>{% endif %}


### PR DESCRIPTION
In govuk-eleventy-plugin 3+ the `app-heading-anchor` link was renamed to `app-link--heading`, and it has specificity that depends on `govuk-link`.

Fixes: 
<img width="411" alt="Screenshot 2022-08-19 at 12 29 03" src="https://user-images.githubusercontent.com/319055/185608950-d9ddbfd0-a3ea-4108-a874-da459944f719.png">