### PR TITLE
Don't include the current page in breadcrumb

### DIFF
--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,6 +1,5 @@
 {
   "layout": "post",
-  "includeInBreadcrumbs": true,
   "permalink": "{{ page.filePathStem | replace('posts/', '') }}/",
   "tags": ["post"]
 }


### PR DESCRIPTION
This is a slightly contentious one, but GOV.UK doesn't include the current page within the breadcrumb, and the Design System guidance suggests not to either:

> The breadcrumb should start with your ‘home’ page and end with the parent section of the current page.