### PR TITLE
Add support notices and replace GOV.UK branding

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,15 +1,25 @@
 module.exports = function (eleventyConfig) {
-  // Plugins
+  // Options to customise the appearance of your design history
+  // https://x-govuk.github.io/govuk-eleventy-plugin/options/
   eleventyConfig.addPlugin(require('govuk-eleventy-plugin'), {
     stylesheets: [
       '/styles/application.css'
     ],
     headingPermalinks: true,
     header: {
+      organisationLogo: false,
       productName: 'Design history',
       search: {
         indexPath: '/search.json',
         sitemapPath: '/sitemap'
+      }
+    },
+    footer: {
+      contentLicence: {
+        html: 'An unofficial community project. <a class="govuk-footer__link" href="https://github.com/x-govuk/x-govuk.github.io">GitHub source</a>.'
+      },
+      copyright: {
+        text: '© X-GOVUK'
       }
     }
   })

--- a/app/_components/email/_email.scss
+++ b/app/_components/email/_email.scss
@@ -1,46 +1,13 @@
 .app-email {
-  @include govuk-font($size: false);
   border: $govuk-border-width solid $govuk-border-colour;
   padding: govuk-spacing(4);
   margin-bottom: govuk-spacing(8);
   max-width: 40rem;
 
-  h1 {
-    @extend %govuk-heading-xl;
-  }
-
-  h2 {
-    @extend %govuk-heading-l;
-  }
-
-  h3 {
-    @extend %govuk-heading-m;
-  }
-
-  p {
-    @extend %govuk-body-m;
-  }
-
-  ol {
-    @extend %govuk-list;
-    @extend %govuk-list--number;
-  }
-
-  ul {
-    @extend %govuk-list;
-    @extend %govuk-list--bullet;
-  }
-
-  a {
-    @extend %govuk-link;
-  }
-
-  // Used when showing screenshots of HTML email
-  img:first-of-type {
-    margin: - govuk-spacing(4);
-    width: calc(100% + #{govuk-spacing(4) + govuk-spacing(4)});
-    max-width: none;
-    outline: 0;
+  h1, h2, h3, h4 {
+    @include govuk-typography-responsive($size: 27);
+    @include govuk-typography-weight-bold;
+    margin-bottom: govuk-spacing(4);
   }
 }
 

--- a/app/_components/email/template.njk
+++ b/app/_components/email/template.njk
@@ -1,6 +1,6 @@
 <div class="app-email{%- if params.classes %} {{ params.classes }}{% endif %}">
 {%- if params.subject -%}
-  <h3 class="app-email__subject">{{- params.subject | safe if params.subject -}}</h3>
+  <h3 class="app-email__subject govuk-heading-m">{{- params.subject | safe if params.subject -}}</h3>
 {%- endif %}
 {{- params.content | markdown | safe if params.content -}}
 </div>

--- a/app/styles/application.scss
+++ b/app/styles/application.scss
@@ -1,3 +1,2 @@
 @import "govuk-frontend/govuk/base";
-@import "govuk-frontend/govuk/core/all";
 @import "../_components/all";


### PR DESCRIPTION
GDS is getting support requests for this project, not helped by the example site looking like a project they maintain. This PR does the following:

* ~~Adds notices to `README.md` and the example site outlining who maintains this project, and where to get support.~~ Merged into `main`.
* Replace the GOV.UK branding with that of X-GOVUK. Addresses #190.
* Adds a comment to Eleventy configuration file that links to [GOV.UK Eleventy Plugin options](https://x-govuk.github.io/govuk-eleventy-plugin/options/), hopefully making it clearer how this branding can be replaced with that of your own organisation.

There is also a separate issue with the styling of the email component. This currently requires importing `govuk-frontend`’s typography helpers, which in turn override the default font set in the configuration file. As this component inherits prose styles, it needn’t be as heavy handed in how it determines email typography, so have remove this dependency. Possibly a separate PR, but is related to removing GOV.UK branding above.