### PR TITLE
Update post template to remove appDocumentFooter

### DIFF
--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -6,10 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {{ appDocumentHeader({
-        title: title | noOrphans
-      }) }}
-
-      {{ appDocumentFooter({
+        title: title | noOrphans,
         date: date,
         modified: modified,
         author: author,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^1.0.2",
-        "govuk-eleventy-plugin": "^3.0.3",
+        "govuk-eleventy-plugin": "^4.0.0",
         "http-server": "^14.1.1",
-        "rimraf": "^3.0.2",
+        "rimraf": "^4.0.4",
         "sass": "^1.56.0"
       },
       "devDependencies": {
@@ -2477,6 +2477,21 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
@@ -2736,9 +2751,9 @@
       }
     },
     "node_modules/govuk-eleventy-plugin": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-3.0.3.tgz",
-      "integrity": "sha512-/a9TlXssVJjQjhc10cqhlMuaZdkGYKAaLVrqaLBARAla4vQOzHlCrRtasS5qGVRlX9cHvpeOg8U38wllEZcn6g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-4.0.0.tgz",
+      "integrity": "sha512-I4+DZqQYpLjRf4BelIjGHHJucW1by6HLSob3uqqxjCn0oGn7tNGX9WFUNCYshS4fFdAK3UCWxmlIESjrmFmafQ==",
       "dependencies": {
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
@@ -2760,7 +2775,7 @@
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
         "markdown-it-table-of-contents": "^0.6.0",
-        "rimraf": "^3.0.2",
+        "rimraf": "^4.0.4",
         "rollup": "^3.9.0",
         "sass": "^1.45.1",
         "smartypants": "^0.1.6"
@@ -2798,6 +2813,157 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/@rollup/plugin-commonjs": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+      "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/@rollup/plugin-node-resolve": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+      "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.42.0"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+    },
+    "node_modules/govuk-prototype-components/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "node_modules/govuk-prototype-components/node_modules/@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/govuk-eleventy-plugin": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-3.0.2.tgz",
+      "integrity": "sha512-CZCsaVfsnQdGGuPvH/GccOZyIon+C10sR+KcKiavhTaQZKg/l9BUio8djjLNlII6UPaR646JpeigEilXQVP6wA==",
+      "dependencies": {
+        "@11ty/eleventy": "^1.0.0",
+        "@11ty/eleventy-navigation": "^0.3.2",
+        "@11ty/eleventy-plugin-rss": "^1.1.2",
+        "@rollup/plugin-commonjs": "^22.0.0",
+        "@rollup/plugin-node-resolve": "^13.1.1",
+        "deepmerge": "^4.2.2",
+        "govuk-frontend": "^4.3.0",
+        "govuk-prototype-components": "^1.0.0",
+        "luxon": "^3.0.1",
+        "markdown-it-abbr": "^1.0.4",
+        "markdown-it-anchor": "^8.4.1",
+        "markdown-it-deflist": "^2.1.0",
+        "markdown-it-footnote": "^3.0.3",
+        "markdown-it-govuk": "^0.1.0",
+        "markdown-it-image-figures": "^2.0.0",
+        "markdown-it-ins": "^3.0.1",
+        "markdown-it-mark": "^3.0.1",
+        "markdown-it-sub": "^1.0.0",
+        "markdown-it-sup": "^1.0.0",
+        "markdown-it-table-of-contents": "^0.6.0",
+        "rimraf": "^3.0.2",
+        "rollup": "^2.62.0",
+        "sass": "^1.45.1",
+        "smartypants": "^0.1.6"
+      },
+      "engines": {
+        "node": "^16.0.0"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/luxon": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/govuk-prototype-components/node_modules/rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/graceful-fs": {
@@ -5457,14 +5623,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.0.4.tgz",
+      "integrity": "sha512-R0hoVr9xTwemarQjoWlNt/nb5dEGVTBhVdkRmEX2zEkT8T6onH0XKiGjuaC7rNNj/gYzY2p4NVRJ3sjO1ascHQ==",
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5922,6 +6088,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -8700,6 +8872,17 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -8880,9 +9063,9 @@
       }
     },
     "govuk-eleventy-plugin": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-3.0.3.tgz",
-      "integrity": "sha512-/a9TlXssVJjQjhc10cqhlMuaZdkGYKAaLVrqaLBARAla4vQOzHlCrRtasS5qGVRlX9cHvpeOg8U38wllEZcn6g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-4.0.0.tgz",
+      "integrity": "sha512-I4+DZqQYpLjRf4BelIjGHHJucW1by6HLSob3uqqxjCn0oGn7tNGX9WFUNCYshS4fFdAK3UCWxmlIESjrmFmafQ==",
       "requires": {
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",
@@ -8904,7 +9087,7 @@
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
         "markdown-it-table-of-contents": "^0.6.0",
-        "rimraf": "^3.0.2",
+        "rimraf": "^4.0.4",
         "rollup": "^3.9.0",
         "sass": "^1.45.1",
         "smartypants": "^0.1.6"
@@ -8932,6 +9115,125 @@
         "eventslibjs": "^1.2.0",
         "govuk-eleventy-plugin": "^3.0.0",
         "govuk-frontend": "^4.1.0"
+      },
+      "dependencies": {
+        "@rollup/plugin-commonjs": {
+          "version": "22.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+          "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+          "requires": {
+            "@rollup/pluginutils": "^3.1.0",
+            "commondir": "^1.0.1",
+            "estree-walker": "^2.0.1",
+            "glob": "^7.1.6",
+            "is-reference": "^1.2.1",
+            "magic-string": "^0.25.7",
+            "resolve": "^1.17.0"
+          }
+        },
+        "@rollup/plugin-node-resolve": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+          "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+          "requires": {
+            "@rollup/pluginutils": "^3.1.0",
+            "@types/resolve": "1.17.1",
+            "deepmerge": "^4.2.2",
+            "is-builtin-module": "^3.1.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.19.0"
+          }
+        },
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          },
+          "dependencies": {
+            "estree-walker": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+              "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+            }
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+        },
+        "@types/resolve": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+          "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "govuk-eleventy-plugin": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-3.0.2.tgz",
+          "integrity": "sha512-CZCsaVfsnQdGGuPvH/GccOZyIon+C10sR+KcKiavhTaQZKg/l9BUio8djjLNlII6UPaR646JpeigEilXQVP6wA==",
+          "requires": {
+            "@11ty/eleventy": "^1.0.0",
+            "@11ty/eleventy-navigation": "^0.3.2",
+            "@11ty/eleventy-plugin-rss": "^1.1.2",
+            "@rollup/plugin-commonjs": "^22.0.0",
+            "@rollup/plugin-node-resolve": "^13.1.1",
+            "deepmerge": "^4.2.2",
+            "govuk-frontend": "^4.3.0",
+            "govuk-prototype-components": "^1.0.0",
+            "luxon": "^3.0.1",
+            "markdown-it-abbr": "^1.0.4",
+            "markdown-it-anchor": "^8.4.1",
+            "markdown-it-deflist": "^2.1.0",
+            "markdown-it-footnote": "^3.0.3",
+            "markdown-it-govuk": "^0.1.0",
+            "markdown-it-image-figures": "^2.0.0",
+            "markdown-it-ins": "^3.0.1",
+            "markdown-it-mark": "^3.0.1",
+            "markdown-it-sub": "^1.0.0",
+            "markdown-it-sup": "^1.0.0",
+            "markdown-it-table-of-contents": "^0.6.0",
+            "rimraf": "^3.0.2",
+            "rollup": "^2.62.0",
+            "sass": "^1.45.1",
+            "smartypants": "^0.1.6"
+          }
+        },
+        "luxon": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+          "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+        },
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rollup": {
+          "version": "2.79.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+          "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -10967,12 +11269,9 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "requires": {
-        "glob": "^7.1.3"
-      }
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.0.4.tgz",
+      "integrity": "sha512-R0hoVr9xTwemarQjoWlNt/nb5dEGVTBhVdkRmEX2zEkT8T6onH0XKiGjuaC7rNNj/gYzY2p4NVRJ3sjO1ascHQ=="
     },
     "rollup": {
       "version": "3.9.1",
@@ -11325,6 +11624,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^1.0.2",
-    "govuk-eleventy-plugin": "^3.0.3",
+    "govuk-eleventy-plugin": "^4.0.0",
     "http-server": "^14.1.1",
-    "rimraf": "^3.0.2",
+    "rimraf": "^4.0.4",
     "sass": "^1.56.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The `appDocumentFooter` component was removed in `govuk-eleventy-plugin` v3.0.3 (see https://github.com/x-govuk/govuk-eleventy-plugin/pull/95). That included a breaking change, that was uncaught, and thus released in a patch release of the plug-in.

This PR removes `appDocumentFooter` from the post template, but wondering if a few other changes should be made:

- [x] Now: Release `govuk-eleventy-plugin` v3.0.3 as v4.0.0, and mark v3.0.3 as deprecated in NPM
- [ ] Later: Add blocks to layouts in the plugin, so that customised layouts only need to add the changes, not recreate the layouts, as is happening in this project, and great maintenance cost

Fixes https://github.com/x-govuk/govuk-eleventy-plugin/issues/114