### PR TITLE
Update template with tag pages

### DIFF
--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -10,7 +10,9 @@
         date: date,
         modified: modified,
         author: author,
-        authors: authors
+        authors: authors,
+        tags: tags,
+        tagPages: collections.tagPages
       }) }}
     </div>
 

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -11,8 +11,7 @@
         modified: modified,
         author: author,
         authors: authors,
-        tags: tags,
-        tagPages: collections.tagPages
+        tags: tags
       }) }}
     </div>
 

--- a/app/_layouts/tag.njk
+++ b/app/_layouts/tag.njk
@@ -1,0 +1,1 @@
+{% extends "layouts/tag.njk" %}

--- a/app/_layouts/tag.njk
+++ b/app/_layouts/tag.njk
@@ -6,7 +6,7 @@
       {
         text: options.parentSite.name,
         href: options.parentSite.url
-       } if options.parentSite,
+      } if options.parentSite,
       {
         text: options.homeKey,
         href: "/"

--- a/app/_layouts/tag.njk
+++ b/app/_layouts/tag.njk
@@ -4,7 +4,11 @@
   {{ govukBreadcrumbs({
     items: [
       {
-        text: "Home",
+        text: options.parentSite.name,
+        href: options.parentSite.url
+       } if options.parentSite,
+      {
+        text: options.homeKey,
         href: "/"
       },
       {

--- a/app/_layouts/tag.njk
+++ b/app/_layouts/tag.njk
@@ -1,1 +1,16 @@
 {% extends "layouts/tag.njk" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Tags",
+        href: "/tags"
+      }
+    ]
+  }) }}
+{% endblock %}

--- a/app/_layouts/tags.njk
+++ b/app/_layouts/tags.njk
@@ -1,1 +1,11 @@
 {% extends "layouts/tags.njk" %}
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      }
+    ]
+  }) }}
+{% endblock %}

--- a/app/_layouts/tags.njk
+++ b/app/_layouts/tags.njk
@@ -3,7 +3,11 @@
   {{ govukBreadcrumbs({
     items: [
       {
-        text: "Home",
+        text: options.parentSite.name,
+        href: options.parentSite.url
+       } if options.parentSite,
+      {
+        text: options.homeKey,
         href: "/"
       }
     ]

--- a/app/_layouts/tags.njk
+++ b/app/_layouts/tags.njk
@@ -5,7 +5,7 @@
       {
         text: options.parentSite.name,
         href: options.parentSite.url
-       } if options.parentSite,
+      } if options.parentSite,
       {
         text: options.homeKey,
         href: "/"

--- a/app/_layouts/tags.njk
+++ b/app/_layouts/tags.njk
@@ -1,0 +1,1 @@
+{% extends "layouts/tags.njk" %}

--- a/app/index.md
+++ b/app/index.md
@@ -4,7 +4,7 @@ layout: home
 title: A design history for your GOV.UK service
 description: A permanent record of how your service has developed over time.
 pagination:
-  data: collections.post
+  data: collections.all
   reverse: true
   size: 50
 ---

--- a/app/posts/2019-12-31-example-post.md
+++ b/app/posts/2019-12-31-example-post.md
@@ -12,6 +12,8 @@ screenshots:
       src: 02-search-results.png
     - text: A design history post
       src: 03-a-design-history-post.png
+tags:
+  - examples
 ---
 
 This is an example of a standard design history post – it begins with a preamble about the design and ends with a list of screenshots.

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,5 +1,4 @@
 {
   "layout": "post",
-  "permalink": "{{ page.filePathStem | replace('posts/', '') }}/",
-  "tags": ["post"]
+  "permalink": "{{ page.filePathStem | replace('posts/', '') }}/"
 }

--- a/app/tag.md
+++ b/app/tag.md
@@ -1,0 +1,13 @@
+---
+layout: tag
+pagination:
+  addAllPagesToCollections: true
+  alias: tag
+  data: collections.tags
+  size: 1
+permalink: "/tags/{{ tag | slug }}/"
+eleventyComputed:
+  title: "Pages tagged ‘{{ tag }}’"
+eleventyNavigation:
+  parent: "Tags"
+---

--- a/app/tag.md
+++ b/app/tag.md
@@ -1,13 +1,9 @@
 ---
 layout: tag
 pagination:
-  addAllPagesToCollections: true
-  alias: tag
   data: collections.tags
   size: 1
-permalink: "/tags/{{ tag | slug }}/"
-eleventyComputed:
-  title: "Pages tagged ‘{{ tag }}’"
-eleventyNavigation:
-  parent: "Tags"
+  alias: tag
+permalink: '/tags/{{ tag | slug }}/'
+eleventyExcludeFromCollections: true
 ---

--- a/app/tags.md
+++ b/app/tags.md
@@ -1,0 +1,5 @@
+---
+layout: tags
+title: Tags
+permalink: "/tags/"
+---

--- a/app/tags.md
+++ b/app/tags.md
@@ -2,4 +2,5 @@
 layout: tags
 title: Tags
 permalink: "/tags/"
+eleventyExcludeFromCollections: true
 ---


### PR DESCRIPTION
This adds tag pages to the template, following [the instructions from the eleventy plugin](https://x-govuk.github.io/govuk-eleventy-plugin/tagging/).