### PR TITLE
Specify Node.js must be above 18.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "webshot-node": "^0.18.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.17"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=18.17"
   }
 }


### PR DESCRIPTION
This matches the requirement of `govuk-eleventy-plugin`.

Fixes #299