### PR TITLE
Enable GitHub Pages from within action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true # Enable GitHub Pages if it's not already
       - name: Install dependencies
         run: npm ci
       - name: Build with Eleventy


### PR DESCRIPTION
This enables GitHub Pages from the action, so that users don’t get this error, and then have to enable it manually themselves:

```
Error: Get Pages site failed. Please verify that the repository 
has Pages enabled and configured to build using GitHub Actions, 
or consider exploring the `enablement` parameter for this action.
```

Should resolve #304 I think, in that the default template should immediately deploy successfully. Anyone wanting to deploy to another host though would then have to disable it by deleting `deploy.yml` and disabling it from the Settings...