### PR TITLE
Add govuk-link class to links

### DIFF
--- a/app/_layouts/product.njk
+++ b/app/_layouts/product.njk
@@ -38,7 +38,7 @@
       {% for item in collections.all | eleventyNavigation(options.homeKey) %}
         <section class="govuk-grid-column-one-half govuk-!-margin-bottom-6">
           <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
-            <a href="{{ item.url | pretty }}">{{ item.title }}</a>
+            <a class="govuk-link" href="{{ item.url | pretty }}">{{ item.title }}</a>
           </h3>
           <p class="govuk-body">{{ item.excerpt }}</p>
         </section>


### PR DESCRIPTION
Noticed that links weren’t styled correctly when I used this template yesterday, so here’s a wee PR to fix that.